### PR TITLE
Allow dynamic text generation no matter the amount of elements

### DIFF
--- a/modules/bot.rb
+++ b/modules/bot.rb
@@ -26,13 +26,17 @@ class Bot
   def parse_message(data)
     raise 'Wrong data' if data[0][:type].nil? || data[0][:dish].nil?
 
+    text = "Idag #{Time.day_of_week} \n"
+    data.each do |e|
+      text += "#{e[:type]}: #{e[:dish]}\n"
+    end
+
     { "channel": @channel,
       "blocks": [{
         "type": 'section',
         "text": {
           "type": 'plain_text',
-          "text": "Idag #{Time.day_of_week} \n#{data[0][:type]}: #{data[0][:dish]}" \
-            "\n#{data[1][:type]}: #{data[1][:dish]}"
+          "text": text.chomp
         }
       }] }
   rescue StandardError


### PR DESCRIPTION
Fixes #38 
Allows for dynamic generation of post text, not limited by the number of elements provided as long as they follow the given format. 