### PR TITLE
Multi restaurant support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,8 @@
 # See https://docs.rubocop.org/rubocop/configuration
 AllCops:
     NewCops: enable
+
+Metrics/ClassLength:
+    Max: 200
+Naming/VariableNumber:
+    CheckSymbols: false

--- a/modules/bot.rb
+++ b/modules/bot.rb
@@ -53,7 +53,8 @@ class Bot
         get_alternative_restaurant_menu(@urls[@attempt], "#{data[0][:type]}: #{@closed_message}")
       end
     else
-      text = "*Idag #{Time.day_of_week}* \n#{pre_text.chomp}".chomp + "\n"
+      text = "*Idag #{Time.day_of_week}* \n#{pre_text.chomp}".chomp
+      text += "\n"
 
       data.each do |e|
         text += "#{e[:type]}: #{e[:dish]}\n"

--- a/spec/unit/bot_spec.rb
+++ b/spec/unit/bot_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Bot:' do
                          blocks: [{
                            "type": 'section',
                            "text": {
-                             "type": 'plain_text',
-                             "text": "Idag Unable to fetch current day \nExpress: Pasta Pizza\nExpress2: Soup"
+                             "type": 'mrkdwn',
+                             "text": "*Idag Unable to fetch current day* \nExpress: Pasta Pizza\nExpress2: Soup"
                            }
                          }], channel: '#lunch-menu' }
 


### PR DESCRIPTION
Fixes #44

As inspired by #45  we can add support for multiple restaurants given the first one eg, is closed.
But as opposed to the implementation in #45  this implementation allows for further extending a list of menus to check.
Given that they use the same layout as the ones currently implemented.

If the restaurant's menu is shown differently then the implementation in #45  allows for a easier conversion to a multi restaurant system when they have different layouts.